### PR TITLE
fixing issue #32- nautilius feedback to BRP UI; and issue #34 - Data Widget in Redcap datasource not showing correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 1.0.4
   * fixing issue8 - driver execption: adding additional nautilius issue mappings
   * added additional nautlis mappings -  'SER': 'Serum'
+  * added nautlis error messages to biorepository UI
 
 1.0.3
 -----

--- a/ehb_datasources/drivers/redcap/formBuilderJson.py
+++ b/ehb_datasources/drivers/redcap/formBuilderJson.py
@@ -415,15 +415,17 @@ class FormBuilderJson(object):
             ffi[name]={'type':ft}
             field_class="field_input"
             text_field_id="input_"+field.get('field_name')
+            today_button=''
             if field.get('text_validation_type_or_show_slider_number') == 'date_ymd':
                 field_class="field_input_date form-control"
                 text_field_id="date"+text_field_id
                 today_button="""<input type="button" value="Today" class="todaybutton" id="datebtn_{0}" /> <br/>
                              <span style="color:red" class="datespan" id="datespan_{0}"></span>""".format(field.get('field_name'))
-                return """<div class="col-xs-3 date-field"><div class="input-group date"><input style="min-width: 100px;" type="text" value="{0}" name="{1}" class="{2}" id="{3}" {4} /><span class="input-group-addon"><i class="glyphicon glyphicon-th"></i></span></div></div>{5}
-                      """.format(value, name, field_class, text_field_id, onchange, today_button)
-            return """<input type="text" value="{0}" name="{1}" class="{2}" id="{3}" {4} />
-                  """.format(value, name, field_class, text_field_id, onchange)
+            return """<div class="date-field"><div class="input-group date"><input style="min-width: 100px;" type="text" value="{0}" name="{1}" class="{2}" id="{3}" {4} /><span class="input-group-addon"><i class="glyphicon glyphicon-th"></i></span></div></div>{5}
+                    """.format(value, name, field_class, text_field_id, onchange, today_button)
+
+            # return """<input type="text" value="{0}" name="{1}" class="{2}" id="{3}" {4} />{5}
+            #       """.format(value, name, field_class, text_field_id, onchange, today_button)
         elif ft == 'notes':
             ffi[name]={'type':ft}
             return """<textarea rows="5" cols="20" name="{0}" class="field_input" {1}>{2}</textarea>

--- a/ehb_datasources/tests/unit_tests/test_form_builder.py
+++ b/ehb_datasources/tests/unit_tests/test_form_builder.py
@@ -15,9 +15,6 @@ def test_construct_form(form_builder, redcap_metadata_json, redcap_record_json):
         'baseline_visit_data',
         1,
     )
-
-    print("form: " + form)
-    print("form end")
     assert '0GUQDBCDE0EAWN9Q:8LAG76CHO' not in form
     assert '<div><input class="field_input" type="checkbox"  name="meds___1" value="1" style="margin-top:-1px" checked="checked"/> Antibiotic</div>' in form
     assert '<input style="min-width: 100px;" type="text" value="100" name="height" class="field_input" id="input_height"  />' in form

--- a/ehb_datasources/tests/unit_tests/test_form_builder.py
+++ b/ehb_datasources/tests/unit_tests/test_form_builder.py
@@ -15,10 +15,13 @@ def test_construct_form(form_builder, redcap_metadata_json, redcap_record_json):
         'baseline_visit_data',
         1,
     )
+
+    print("form: " + form)
+    print("form end")
     assert '0GUQDBCDE0EAWN9Q:8LAG76CHO' not in form
     assert '<div><input class="field_input" type="checkbox"  name="meds___1" value="1" style="margin-top:-1px" checked="checked"/> Antibiotic</div>' in form
-    assert '<input type="text" value="100" name="height" class="field_input" id="input_height"  />' in form
-    assert '<input type="text" value="20" name="weight" class="field_input" id="input_weight"  />' in form
+    assert '<input style="min-width: 100px;" type="text" value="100" name="height" class="field_input" id="input_height"  />' in form
+    assert 'input style="min-width: 100px;" type="text" value="20" name="weight" class="field_input" id="input_weight"  />' in form
     assert '<textarea rows="5" cols="20" name="comments" class="field_input" >Test Data2</textarea>' in form
 
 


### PR DESCRIPTION
This is adding additional feedback to the BRP UI. When nautilus does not return an error but an empty response it will warn the user that they might not have access to the sample collection in nautilus. 