### PR TITLE
Changes to show redcap error messages

### DIFF
--- a/ehb_datasources/drivers/Base.py
+++ b/ehb_datasources/drivers/Base.py
@@ -261,7 +261,6 @@ class RequestHandler(object):
             self.currentConnection.close()
 
     def processResponse(self, response, path=''):
-        print ("this is the path for processresponse " + path)
         status = response.status
         if status == 200:
             return self.readAndClose(response)

--- a/ehb_datasources/drivers/Base.py
+++ b/ehb_datasources/drivers/Base.py
@@ -10,6 +10,7 @@ import logging
 import re
 import urllib.request, urllib.parse, urllib.error
 
+
 import xml.dom.minidom as xml
 
 log = logging.getLogger('ehb_datasources')
@@ -259,7 +260,8 @@ class RequestHandler(object):
         if self.currentConnection:
             self.currentConnection.close()
 
-    def processResponse(self, response, path=''):
+    def redcap_processResponse (self, response, path =''):
+        print ("this is the path for processresponse " + path)
         status = response.status
         if status == 200:
             return self.readAndClose(response)
@@ -295,6 +297,32 @@ class RequestHandler(object):
                 #[3] -> error message
                 self.closeConnection()
                 raise Exception("You entered " + msg[2] + " for the field " + msg[1]+ ". " + msg [3])
+        elif status == 406:
+            msg = "The data being imported was formatted incorrectly"
+            self.closeConnection()
+            raise Exception(msg)
+        elif status == 404:
+            self.closeConnection()
+            raise PageNotFound(path=path)
+        elif status == 500:
+            self.closeConnection()
+            raise ServerError
+        else:
+            self.closeConnection()
+            msg = 'Unknown response code from server: {}'.format(status)
+            raise Exception(msg)
+
+    def processResponse(self, response, path=''):
+        print ("this is the path for processresponse " + path)
+        status = response.status
+        if status == 200:
+            return self.readAndClose(response)
+        elif status == 201:
+            return self.readAndClose(response)
+        elif status == 400:
+            msg = 'Bad Request: {}'.format(response.read())
+            self.closeConnection()
+            raise Exception (msg)
         elif status == 406:
             msg = "The data being imported was formatted incorrectly"
             self.closeConnection()

--- a/ehb_datasources/drivers/Base.py
+++ b/ehb_datasources/drivers/Base.py
@@ -260,58 +260,6 @@ class RequestHandler(object):
         if self.currentConnection:
             self.currentConnection.close()
 
-    def redcap_processResponse (self, response, path =''):
-        print ("this is the path for processresponse " + path)
-        status = response.status
-        if status == 200:
-            return self.readAndClose(response)
-        elif status == 201:
-            return self.readAndClose(response)
-        elif status == 400:
-            #this means the data being imported isn't formatted correctly
-            #redcap api will return a message
-            msg = response.read()
-            #xml to string
-            msg = msg.decode ("utf-8")
-            #for more than one error, errors are separated by \n
-            if "\n" in msg:
-                msg=msg.split('\n')
-                msgShow =''
-                for error in msg:
-                    error=error.split(',')
-                    #there are 3 parts to error message returned by redcap
-                    #[0] -> user's name
-                    #[1] -> field name
-                    #[2] -> user input
-                    #[3] -> error message
-                    msgShow += "You entered " + error[2] + " for the field " + error[1]+ ". " + error [3] + "<br><br>"
-                self.closeConnection()
-                raise Exception (msgShow)
-            else:
-                #there is only one error message
-                msg = msg.split(',')
-                #there are 3 parts to error message returned by redcap
-                #[0] -> user's name
-                #[1] -> field name
-                #[2] -> user input
-                #[3] -> error message
-                self.closeConnection()
-                raise Exception("You entered " + msg[2] + " for the field " + msg[1]+ ". " + msg [3])
-        elif status == 406:
-            msg = "The data being imported was formatted incorrectly"
-            self.closeConnection()
-            raise Exception(msg)
-        elif status == 404:
-            self.closeConnection()
-            raise PageNotFound(path=path)
-        elif status == 500:
-            self.closeConnection()
-            raise ServerError
-        else:
-            self.closeConnection()
-            msg = 'Unknown response code from server: {}'.format(status)
-            raise Exception(msg)
-
     def processResponse(self, response, path=''):
         print ("this is the path for processresponse " + path)
         status = response.status

--- a/ehb_datasources/drivers/Base.py
+++ b/ehb_datasources/drivers/Base.py
@@ -269,7 +269,7 @@ class RequestHandler(object):
         elif status == 400:
             msg = 'Bad Request: {}'.format(response.read())
             self.closeConnection()
-            raise Exception (msg)
+            raise Exception(msg)
         elif status == 406:
             msg = "The data being imported was formatted incorrectly"
             self.closeConnection()

--- a/ehb_datasources/drivers/Base.py
+++ b/ehb_datasources/drivers/Base.py
@@ -1,4 +1,3 @@
-
 from abc import ABCMeta, abstractmethod
 from .exceptions import PageNotFound, ServerError
 import datetime
@@ -9,12 +8,9 @@ import string
 import logging
 import re
 import urllib.request, urllib.parse, urllib.error
-
-
 import xml.dom.minidom as xml
 
 log = logging.getLogger('ehb_datasources')
-
 
 class Driver(object, metaclass=ABCMeta):
     '''

--- a/ehb_datasources/drivers/redcap/driver.py
+++ b/ehb_datasources/drivers/redcap/driver.py
@@ -10,7 +10,7 @@ from collections import OrderedDict
 from jinja2 import Template
 
 from ehb_datasources.drivers.exceptions import PageNotFound,\
-    ImproperArguments
+    ImproperArguments, ServerError
 from ehb_datasources.drivers.Base import Driver, RequestHandler
 from ehb_datasources.drivers.exceptions import RecordDoesNotExist,\
     RecordCreationError

--- a/ehb_datasources/drivers/redcap/driver.py
+++ b/ehb_datasources/drivers/redcap/driver.py
@@ -468,7 +468,10 @@ class ehbDriver(Driver, GenericDriver):
             data=xml.parseString(record),
             overwrite=overwrite
         ):
-            raise RecordCreationError(self.url, self.path, study_id, 'Unknown')
+            errors = self.write_records(
+                data=xml.parseString(record),
+                overwrite=overwrite)
+            raise RecordCreationError(self.url, self.path, study_id, errors)
         else:
             return study_id
 

--- a/ehb_datasources/drivers/redcap/driver.py
+++ b/ehb_datasources/drivers/redcap/driver.py
@@ -120,7 +120,7 @@ class GenericDriver(RequestHandler):
         response = self.POST(self.path, headers, urllib.parse.urlencode(params))
         if response.status == 201 or response.status == 200:
             # Record was processed properly
-            processed_response = self.processResponse(response, self.path)
+            processed_response = self.redcap_processResponse(response, self.path)
             num_recs_updated = -1
             # This is necessary because the REDCap API changed it's response
             # format for record import at REDCap version 4.8
@@ -140,7 +140,7 @@ class GenericDriver(RequestHandler):
         else:
             # Don't know what happened, let processResponse raise appropriate
             # exception
-            return self.processResponse(response, self.path)
+            return self.redcap_processResponse(response, self.path)
 
     def read_records(self, _format=FORMAT_JSON, _type=TYPE_FLAT,
                      headers=STANDARD_HEADER, rawResponse=False, **kwargs):
@@ -201,7 +201,7 @@ class GenericDriver(RequestHandler):
         else:
             return self.transformResponse(
                 _format,
-                self.processResponse(response, self.path)
+                self.redcap_processResponse(response, self.path)
             )
 
     def read_metadata(self, _format=FORMAT_JSON, headers=STANDARD_HEADER,
@@ -249,7 +249,7 @@ class GenericDriver(RequestHandler):
                 params[item] = self.build_parameter(kwargs.get(item))
 
         params = urllib.parse.urlencode(params).replace('forms', 'forms[]')
-        response = self.processResponse(
+        response = self.redcap_processResponse(
             self.POST(self.path, headers, params),
             self.path
         )

--- a/ehb_datasources/drivers/redcap/driver.py
+++ b/ehb_datasources/drivers/redcap/driver.py
@@ -942,6 +942,5 @@ class ehbDriver(Driver, GenericDriver):
             ):
                 return ['Unknown error. REDCap reports multiple records were' +
                         'updated, should have only been 1.']
-        except Exception:
-            return ['Parse error. REDCap response is an unknown format.' +
-                    ' Please contact system administrator.']
+        except Exception as error:
+            return  repr(error)

--- a/ehb_datasources/drivers/redcap/formBuilderJson.py
+++ b/ehb_datasources/drivers/redcap/formBuilderJson.py
@@ -224,6 +224,17 @@ class FormBuilderJson(object):
       success: function(data){
         if(data.status == 'error'){
           $("#pleaseWaitModal").modal('hide');
+
+          //Check to see if error messages exist prior
+          //to remove them
+          var elementExists = document.getElementById("errorMsg");
+          if (elementExists) {
+            var element = document.getElementById("errorMsg");
+            element.parentNode.removeChild(element);
+          }
+          else {
+
+          }
           $("#errorModal").modal('show');
         }
         else{

--- a/ehb_datasources/drivers/redcap/formBuilderJson.py
+++ b/ehb_datasources/drivers/redcap/formBuilderJson.py
@@ -374,6 +374,7 @@ class FormBuilderJson(object):
     def make_tr_for(self, field, record, master_dep_map, apriori_branch_evals):
         def isRequired():
                 if field.get('required_field') and field.get('required_field')=='y': return '* must provide value'
+                elif field.get('required_field') and field.get('required_field')=='Y': return '* must provide value'
                 else: return ''
 
         def fieldNote():

--- a/ehb_datasources/drivers/redcap/formBuilderJson.py
+++ b/ehb_datasources/drivers/redcap/formBuilderJson.py
@@ -373,7 +373,7 @@ class FormBuilderJson(object):
 
     def make_tr_for(self, field, record, master_dep_map, apriori_branch_evals):
         def isRequired():
-                if field.get('required_field') and field.get('required_field')=='Y': return '* must provide value'
+                if field.get('required_field') and field.get('required_field')=='y': return '* must provide value'
                 else: return ''
 
         def fieldNote():

--- a/ehb_datasources/drivers/redcap/formBuilderJson.py
+++ b/ehb_datasources/drivers/redcap/formBuilderJson.py
@@ -235,7 +235,10 @@ class FormBuilderJson(object):
           else {
 
           }
+
           $("#errorModal").modal('show');
+          $("#errorClass").append("<div id='errorMsg'>" + "<p style='color:#F08080'> <br>[ REDCAP ERROR MESSAGE ] <br>" + data.errors + "</p>" + "</div>");
+
         }
         else{
           if(next_form_url != ""){

--- a/ehb_datasources/drivers/redcap/formBuilderJson.py
+++ b/ehb_datasources/drivers/redcap/formBuilderJson.py
@@ -380,6 +380,47 @@ class FormBuilderJson(object):
                 if field.get('field_note'): return field.get('field_note')
                 else: return ''
 
+        def fieldValidation():
+            redcap_field_validation_map = {
+                'date_dmy': 'YYYY-MM-DD.',
+                'date_mdy': 'YYYY-MM-DD. ',
+                'date_ymd': 'YYYY-MM-DD.',
+                'datetime_dmy': 'YYYY-MM-DD HH:MM (time is in military format)',
+                'datetime_ymd': 'YYYY-MM-DD HH:MM (time is in military format)',
+                'datetime_mdy': 'YYYY-MM-DD HH:MM (time is in military format)',
+                'datetime_seconds_mdy': 'YYYY-MM-DD HH:MM:SS (time is in military format)',
+                'datetime_seconds_ymd': 'YYYY-MM-DD HH:MM:SS (time is in military format) ',
+                'datetime_seconds_dmy': 'YYYY-MM-DD HH:MM:SS (time is in military format) ',
+                'email': 'email@email.com',
+                'integer': 'whole number (no letters or decimal)',
+                'alpha_only': 'letters (no numbers)',
+                'mrn_8d': 'medical record number (8 digits)',
+                'number': 'number (no letters)',
+                'number_1dp': 'number with 1 decimal place #.#',
+                'number_2dp': 'number with 2 decimal place #.##',
+                'number_3dp': 'number with 3 decimal place #.###',
+                'number_4dp': 'number with 4 decimal place #.####',
+                'phone': '10 digit phone number (###)###-####',
+                'ssn': '9 digit social security number ###-##-####',
+                'text_0_150': 'characters (max. 150)',
+                'text_0_200': 'characters (max. 200)',
+                'time': 'time HH:MM (military format)',
+                'time_mm_ss': 'time HH:MM:SS (military format)',
+                'zipcode': '5 or 9 digit zipcode'
+                }
+
+            #if validation note exists for the field
+            if field.get('text_validation_type_or_show_slider_number'):
+                #loop through the validation map to find the correct validation msg to show
+                for validation_key, validation_message in redcap_field_validation_map.items():
+                    if field.get('text_validation_type_or_show_slider_number') == str(validation_key):
+                        return "field value expected is " + str(validation_message)
+                #validation doesn't match with any of the keys above.
+                #print the validation note anyways
+                return "field value expected is: " + field.get('text_validation_type_or_show_slider_number')
+            #no validation note exists
+            else: return ''
+
         section_header = field.get('section_header')
         header = ''
         radio_reset = ''

--- a/ehb_datasources/drivers/redcap/formBuilderJson.py
+++ b/ehb_datasources/drivers/redcap/formBuilderJson.py
@@ -407,8 +407,8 @@ class FormBuilderJson(object):
                 'text_0_150': 'characters (max. 150)',
                 'text_0_200': 'characters (max. 200)',
                 'time': 'time HH:MM (military format)',
-                'time_mm_ss': 'time HH:MM:SS (military format)',
-                'zipcode': '5 or 9 digit zipcode'
+                'time_mm_ss': 'time MM:SS',
+                'zipcode': '5 or 9 digit zipcode (#####-####)'
                 }
 
             #if validation note exists for the field

--- a/ehb_datasources/drivers/redcap/formBuilderJson.py
+++ b/ehb_datasources/drivers/redcap/formBuilderJson.py
@@ -225,8 +225,9 @@ class FormBuilderJson(object):
         if(data.status == 'error'){
           $("#pleaseWaitModal").modal('hide');
 
-          //Check to see if error messages exist prior
-          //to remove them
+          // Check to see if error messages exist prior
+          // to remove them
+
           var elementExists = document.getElementById("errorMsg");
           if (elementExists) {
             var element = document.getElementById("errorMsg");

--- a/ehb_datasources/drivers/redcap/formBuilderJson.py
+++ b/ehb_datasources/drivers/redcap/formBuilderJson.py
@@ -434,16 +434,17 @@ class FormBuilderJson(object):
         return """{0}
                   <tr id="{5}" {6}>
                   <td><div>{1}</div><div style="color:red; font-size:12px;">{2}</div></td>
-                  <td><div>{3}</div><div style="color:blue; font-size:12px;">{4}</div>{7}</td>
+                  <td><div>{3}</div><div style="color:blue; font-size:12px;">{4}</div><div style="color:grey; font-size:10px;">{8}</div>{7}</td>
                   </tr>
-               """.format(header,
-                          field.get('field_label'),
-                          isRequired(),
-                          self.build_field(field, record, master_dep_map),
-                          fieldNote(),
-                          field.get('field_name'),
-                          dis,
-                          radio_reset
+               """.format(header, #{0}
+                          field.get('field_label'), #{1}
+                          isRequired(), #{2}
+                          self.build_field(field, record, master_dep_map), #{3}
+                          fieldNote(), #{4}
+                          field.get('field_name'), #{5}
+                          dis,#{6}
+                          radio_reset,#{7}
+                          fieldValidation() #{8}
                    )
 
     def build_fld_on_change_function(self, fld_name, master_dep_map):

--- a/ehb_datasources/tests/unit_tests/test_redcap_driver.py
+++ b/ehb_datasources/tests/unit_tests/test_redcap_driver.py
@@ -549,8 +549,7 @@ def test_process_form_badrcresponse(mocker, driver, driver_configuration_long, r
 
     driver.write_records = mocker.MagicMock(side_effect=ServerError)
     errors = driver.processForm(request, external_record, form_spec='0_0')
-    assert 'Parse error. REDCap response is an unknown format. Please contact system administrator.' in errors
-
+    assert 'ServerError()' in errors
 
 def test_process_form_bad_metadata_norecordid(mocker, driver, driver_configuration_long, redcap_metadata_xml, redcap_form_datastring):
     # Mocks


### PR DESCRIPTION
- in redcap/driver.py: raise the exception to read the redcap error message (354eb55, 140de53)
- in Base.py: processResponse was changed to read the message from Redcap's API (4019efb) 
- in formBuilder.py: display error message through javascript (bc68f5a, d354ca5)
- in formBuilder.py: create validation map and method fieldValidation (9e8c96d, f8ef2f8)
- in formBuilder.py: Y->y so that isRequired message displays on table (fd29c74)
- changed test_process_form_badresponse unit test so that it asserts a different message (02dd17c)


